### PR TITLE
Fixes #24

### DIFF
--- a/src/Microsoft.Dism/DismApi.cs
+++ b/src/Microsoft.Dism/DismApi.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Dism
         public static void CommitImage(DismSession session, bool discardChanges, Microsoft.Dism.DismProgressCallback progressCallback, object userData)
         {
             // Create the flags
-            UInt32 flags = discardChanges ? DismApi.DISM_DISCARD_IMAGE : DismApi.DISM_COMMIT_MASK;
+            UInt32 flags = discardChanges ? DismApi.DISM_DISCARD_IMAGE : DismApi.DISM_COMMIT_IMAGE;
 
             // Create a DismProgress object to wrap the callback and allow cancellation
             var progress = new DismProgress(progressCallback, userData);
@@ -1307,7 +1307,7 @@ namespace Microsoft.Dism
         public static void UnmountImage(string mountPath, bool commitChanges, Dism.DismProgressCallback progressCallback, object userData)
         {
             // Determine flags
-            var flags = commitChanges ? DismApi.DISM_COMMIT_MASK : DismApi.DISM_DISCARD_IMAGE;
+            var flags = commitChanges ? DismApi.DISM_COMMIT_IMAGE : DismApi.DISM_DISCARD_IMAGE;
 
             // Create a DismProgress object to wrap the callback and allow cancellation
             var progress = new DismProgress(progressCallback, userData);

--- a/src/Microsoft.Dism/NativeConstants.cs
+++ b/src/Microsoft.Dism/NativeConstants.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Dism
         /// <summary>
         /// Indicates to the DismUnmountImage Function that all changes should be saved. This flag is equivalent to using DISM_COMMIT_IMAGE, DISM_COMMIT_GENERATE_INTEGRITY, and DISM_COMMIT_APPEND.
         /// </summary>
-        public const uint DISM_COMMIT_MASK = DISM_COMMIT_IMAGE | DISM_COMMIT_GENERATE_INTEGRITY | DISM_COMMIT_APPEND;
+        public const uint DISM_COMMIT_MASK = 0xFFFF0000;
 
         /// <summary>
         /// Indicates to the DismCommitImage Function or the DismUnmountImage Function that changes to the image should not be saved.


### PR DESCRIPTION
Updates DISM_COMMIT_MASK to 0xFFFF0000, and makes two changes to the DismApi managed methods (Commit and Unmount) to use the DISM_COMMIT_IMAGE flag instead of the DISM_COMMIT_MASK flag.